### PR TITLE
Add books number of pages

### DIFF
--- a/client/src/components/Book/BookFull.tsx
+++ b/client/src/components/Book/BookFull.tsx
@@ -41,6 +41,7 @@ export function BookFull(props: BookFullProps) {
                 />
                 <Author author={book.author} />
                 <EbookDownloadLinks book={book} />
+                {book.nbPages} pages
                 <BookIntroContainer bookId={book.id} hocToolkit={hocToolkit} />
               </div>
             </div>

--- a/client/src/domain/core.ts
+++ b/client/src/domain/core.ts
@@ -10,6 +10,7 @@ export interface Book {
   author: Author;
   title: string;
   subtitle: string | null;
+  nbPages: number | null;
   coverUrl: string | null;
   slug: string;
   genres: Genre[];

--- a/client/src/repositories/BooksGraphqlRepository.ts
+++ b/client/src/repositories/BooksGraphqlRepository.ts
@@ -36,6 +36,7 @@ query {
     lang
     title
     subtitle
+    nbPages
     slug
     coverPath
     genres
@@ -69,6 +70,7 @@ query bookById($bookId: BookId!) {
       lang
       title
       subtitle
+      nbPages
       slug
       coverPath
       genres
@@ -156,6 +158,7 @@ query booksByGenre($genre: String!, $lang: String, $page: Int, $nbPerPage: Int) 
       lang
       title
       subtitle
+      nbPages
       slug
       coverPath
       genres
@@ -219,6 +222,7 @@ query booksByAuthor($authorId: AuthorId!, $lang: String, $page: Int, $nbPerPage:
       lang
       title
       subtitle
+      nbPages
       slug
       coverPath
       genres
@@ -310,6 +314,7 @@ function mapBookFromServer(row: ServerResponse.BookData): Book {
     lang: row.lang,
     title: row.title,
     subtitle: row.subtitle,
+    nbPages: row.nbPages,
     slug: row.slug,
     author: {
       id: row.author.authorId,

--- a/client/src/repositories/graphql-server-responses.ts
+++ b/client/src/repositories/graphql-server-responses.ts
@@ -2,6 +2,7 @@ export interface BookData {
   bookId: string;
   title: string;
   subtitle: string | null;
+  nbPages: number | null;
   coverPath: string | null;
   lang: string;
   slug: string;

--- a/server/Makefile
+++ b/server/Makefile
@@ -31,7 +31,7 @@ import_gutenberg_books: VERBOSITY?=1
 import_gutenberg_books:
 	@echo "\033[36mPopulating 'library' tables from 'import.gutenberg_raw_data' content...\033[0m"
 	time ${PSQL} --no-psqlrc \
-		-c  "select * from import.create_books_from_raw_rdfs(wipe_previsous_books => true, verbosity => ${VERBOSITY}::integer);"
+		-c  "select * from import.create_books_from_raw_rdfs(wipe_previous_books => true, verbosity => ${VERBOSITY}::integer);"
 
 .phony: update_computed_data_tables
 update_computed_data_tables: PG_FUNCTIONS=library_view.update_all_books_computed_data library_view.update_all_authors_computed_data
@@ -84,9 +84,9 @@ dump_data_to_import_db_python_install:
 .phony: rsync_and_import_book
 rsync_and_import_book: OPTS=
 rsync_and_import_book:
-	${PYTHON_DC_PREFIX} \
+	${DC_RUN} --entrypoint python -e PYTHONPATH=/pg-rdfs-indexing/src \
 		-v ${GUTENBERG_GENERATED_COLLECTION_PATH}:/gutenberg-mirror/generated-collection \
-		python \
+		pg_rdf_indexing \
 		bin/rsync-and-import-book.py ${PG_BOOK_ID} /gutenberg-mirror/generated-collection ${OPTS}
 
 .phony: start_dev_api_admin

--- a/server/api/django/apps/api_public/models.py
+++ b/server/api/django/apps/api_public/models.py
@@ -9,6 +9,7 @@ class Book(models.Model):
     subtitle = models.CharField(max_length=255, null=True)
     lang = models.CharField(max_length=3)
     highlight = models.PositiveIntegerField(default=0)
+    size = models.PositiveIntegerField(default=0)
     author = models.ForeignKey('Author', on_delete=models.DO_NOTHING, related_name='books', db_column='author_id')
     genres = models.ManyToManyField('Genre', related_name='genres', db_table='library\".\"book_genre')
 

--- a/server/db/editing.sql
+++ b/server/db/editing.sql
@@ -31,3 +31,4 @@ insert into webapp.settings(name, value) values
 ;
 
 commit;
+

--- a/server/db/schema/library.sql
+++ b/server/db/schema/library.sql
@@ -25,6 +25,7 @@ create table library.book (
   lang varchar(3) collate "C" not null,
   title varchar not null,
   subtitle varchar null,
+  size integer null,
   highlight integer not null default 0,
   author_id int references library.author(author_id) not null
 );

--- a/server/pg-rdfs-indexing/src/pg_import/db.py
+++ b/server/pg-rdfs-indexing/src/pg_import/db.py
@@ -51,7 +51,7 @@ def _book_to_dict_for_db(books_root_path: str, book: parsing.BookProcessingResul
         'id': book.book_id,
         'rdf_content': book.rdf_file_content,
         'assets': book.assets_as_json(books_root_path),
-        'intro': book.intro
+        'intro': book.intro,
     }
 
 

--- a/server/pg-rdfs-indexing/src/pg_import/parsing.py
+++ b/server/pg-rdfs-indexing/src/pg_import/parsing.py
@@ -32,7 +32,7 @@ class BookProcessingResult(t.NamedTuple):
     book_id: str
     rdf_file_content: str
     assets: t.Dict[BookAssetType, BookAsset]
-    intro: t.Optional[str]
+    intro: t.Union[str, None]
 
     def assets_as_json(self, books_root_path: str) -> str:
         assets_as_simple_structures = {
@@ -47,6 +47,8 @@ def process_book_from_pg_rdf_file(pg_book_id: str, rdf_file: Path) -> t.Optional
     assets = get_pg_book_assets(rdf_file_dir)
 
     if BookAssetType.EPUB not in assets:
+        # Allowing people to download books in epub format is our top priority,
+        # so we don't handle PG items that don't have an epub file
         return None
 
     rdf_file_content = rdf_file.read_text(encoding='utf-8')


### PR DESCRIPTION
We store the size of the "on images" epub files, as stated in the Project Gutenberg RDF files, and compute a "number of pages" for the books, by dividing those file sizes by a ratio.

This ratio doesn't work for all books, but for most of them if should roughly do the job.

