### PR TITLE
Enhance our GraphQL API

### DIFF
--- a/client/src/domain/queries.ts
+++ b/client/src/domain/queries.ts
@@ -22,7 +22,7 @@ export interface BooksLanguagesRepository {
 }
 
 export interface QuickSearchResult {
-  readonly resultType: "book" | "author";
+  readonly resultType: "BOOK" | "AUTHOR";
   readonly book: QuickSearchResultBook | null;
   readonly author: QuickSearchResultAuthor;
   readonly highlight: number;

--- a/client/src/repositories/BooksGraphqlRepository.ts
+++ b/client/src/repositories/BooksGraphqlRepository.ts
@@ -62,33 +62,21 @@ query {
 
   public async getBookById(bookId: string): Promise<BookWithGenreStats | null> {
     const graphqlQuery = `
-query bookById($bookId: BookId!) {
+query bookWithGenreStatsById($bookId: BookId!) {
 
-  bookWithGenresStats(bookId: $bookId) {
-    book {
-      bookId
-      lang
-      title
-      subtitle
-      nbPages
-      slug
-      coverPath
-      genres
-      epubSize
-      mobiSize
-
-      author {
-        authorId
-        firstName
-        lastName
-        birthYear
-        deathYear
-        slug
-        nbBooks
-      }
-    }
-
-    genresStats {
+  book(bookId: $bookId) {
+    bookId
+    lang
+    title
+    subtitle
+    nbPages
+    slug
+    coverPath
+    genres
+    epubSize
+    mobiSize
+    
+    genresWithStats {
       title
       nbBooks
 
@@ -97,14 +85,23 @@ query bookById($bookId: BookId!) {
         nbBooks
       }
     }
+
+    author {
+      authorId
+      firstName
+      lastName
+      birthYear
+      deathYear
+      slug
+      nbBooks
+    }
   }
 
 }
 
 `;
     const response = await this.requestGraphql(graphqlQuery, { bookId });
-    const bookDataFromServer: ServerResponse.BookWithGenreStats =
-      response.data.data.bookWithGenresStats;
+    const bookDataFromServer: ServerResponse.BookFullData = response.data.data.book;
     const bookWithGenreStats = mapBookWithGenreStatsFromServer(bookDataFromServer);
 
     return Promise.resolve(bookWithGenreStats);
@@ -122,10 +119,12 @@ query quickSearch($pattern: String!, $lang: String) {
 
   quickSearch(search: $pattern, lang: $lang) {
     type
-    bookId
-    bookLang
-    bookTitle
-    bookSlug
+    ... on QuickSearchResultBook {
+      bookId
+      bookLang
+      bookTitle
+      bookSlug
+    }
     authorId
     authorFirstName
     authorLastName
@@ -151,7 +150,7 @@ query quickSearch($pattern: String!, $lang: String) {
     const graphqlQuery = `
 query booksByGenre($genre: String!, $lang: String, $page: Int, $nbPerPage: Int) {
 
-  booksByGenre(genre: $genre, lang: $lang, page: $page, nbPerPage: $nbPerPage) {
+  books(genre: $genre, lang: $lang, page: $page, nbPerPage: $nbPerPage) {
 
     books {
       bookId
@@ -193,7 +192,7 @@ query booksByGenre($genre: String!, $lang: String, $page: Int, $nbPerPage: Int) 
     });
 
     const booksWithPagination: ServerResponse.BooksDataWithPagination<ServerResponse.BookData> =
-      response.data.data.booksByGenre;
+      response.data.data.books;
     const paginationData: PaginationResponseData = getPaginationResponseDataFromServerResponse(
       booksWithPagination.meta
     );
@@ -215,7 +214,7 @@ query booksByGenre($genre: String!, $lang: String, $page: Int, $nbPerPage: Int) 
     const graphqlQuery = `
 query booksByAuthor($authorId: AuthorId!, $lang: String, $page: Int, $nbPerPage: Int) {
 
-  booksByAuthor(authorId: $authorId, lang: $lang, page: $page, nbPerPage: $nbPerPage) {
+  books(authorId: $authorId, lang: $lang, page: $page, nbPerPage: $nbPerPage) {
 
     books {
       bookId
@@ -257,7 +256,7 @@ query booksByAuthor($authorId: AuthorId!, $lang: String, $page: Int, $nbPerPage:
     });
 
     const booksWithPagination: ServerResponse.BooksDataWithPagination<ServerResponse.BookData> =
-      response.data.data.booksByAuthor;
+      response.data.data.books;
     const paginationData: PaginationResponseData = getPaginationResponseDataFromServerResponse(
       booksWithPagination.meta
     );
@@ -338,12 +337,12 @@ function mapBookFullFromServer(row: ServerResponse.BookFullData): BookFull {
   };
 }
 
-function mapBookWithGenreStatsFromServer(
-  row: ServerResponse.BookWithGenreStats
-): BookWithGenreStats {
+function mapBookWithGenreStatsFromServer(row: ServerResponse.BookFullData): BookWithGenreStats {
   return {
-    book: mapBookFullFromServer(row.book),
-    genresWithStats: row.genresStats.map(mapGenreWithStatsFromServer),
+    book: mapBookFullFromServer(row),
+    genresWithStats: row.genresWithStats
+      ? row.genresWithStats.map(mapGenreWithStatsFromServer)
+      : [],
   };
 }
 

--- a/client/src/repositories/BooksGraphqlRepository.ts
+++ b/client/src/repositories/BooksGraphqlRepository.ts
@@ -365,7 +365,7 @@ function mapQuickSearchDataFromServer(row: ServerResponse.QuickSearchData): Quic
   return {
     resultType: rowType,
     book:
-      "book" === rowType
+      "BOOK" === rowType
         ? {
             id: row.bookId as string,
             title: row.bookTitle as string,

--- a/client/src/repositories/graphql-server-responses.ts
+++ b/client/src/repositories/graphql-server-responses.ts
@@ -32,7 +32,7 @@ export interface BookWithGenreStats {
 }
 
 export interface QuickSearchData {
-  type: "book" | "author";
+  type: "BOOK" | "AUTHOR";
   bookId: string | null;
   bookTitle: string | null;
   bookLang: string;

--- a/client/src/repositories/graphql-server-responses.ts
+++ b/client/src/repositories/graphql-server-responses.ts
@@ -8,6 +8,8 @@ export interface BookData {
   slug: string;
   genres: string[];
   author: AuthorData;
+
+  genresWithStats?: GenreWithStats[];
 }
 
 export interface AuthorData {
@@ -26,17 +28,12 @@ export interface BookFullData extends BookData {
   intro: string;
 }
 
-export interface BookWithGenreStats {
-  book: BookFullData;
-  genresStats: GenreWithStats[];
-}
-
 export interface QuickSearchData {
   type: "BOOK" | "AUTHOR";
-  bookId: string | null;
-  bookTitle: string | null;
-  bookLang: string;
-  bookSlug: string;
+  bookId?: string | null;
+  bookTitle?: string | null;
+  bookLang?: string;
+  bookSlug?: string;
   authorId: string;
   authorFirstName: string;
   authorLastName: string;

--- a/server/Makefile
+++ b/server/Makefile
@@ -81,10 +81,6 @@ rsync_and_import_book:
 		pg_rdf_indexing \
 		bin/rsync-and-import-book.py ${PG_BOOK_ID} /gutenberg-mirror/generated-collection ${OPTS}
 
-.phony: start_dev_api_admin
-start_dev_api_admin:
-	cd api-admin && make start_dev
-
 .phony: psql
 psql: .psql-history
 	${PSQL}
@@ -117,7 +113,8 @@ django_runserver:
 
 .phony: start_graphql_api
 start_graphql_api:
-	docker-compose up -d nginx && docker-compose logs -f --tail=0 django
+	docker-compose kill django || true
+	docker-compose up -d nginx && docker-compose logs -f --tail=10 django
 
 .phony: pg_dump_raw_gutenberg_data
 pg_dump_raw_gutenberg_data:

--- a/server/api/django/apps/api_public/graphql/library/query.py
+++ b/server/api/django/apps/api_public/graphql/library/query.py
@@ -21,8 +21,27 @@ LANG_ALL = 'all'
 
 
 class Query():
-    all_books = graphene.List(gql_schema.BookType, offset=graphene.Int(), limit=graphene.Int())
-    all_authors = graphene.List(gql_schema.AuthorType, offset=graphene.Int(), limit=graphene.Int())
+    book = graphene.Field(
+        gql_schema.BookType,
+        book_id=gql_schema.BookId(required=True)
+    )
+    author = graphene.Field(
+        gql_schema.AuthorType,
+        author_id=gql_schema.AuthorId(),
+    )
+    books = graphene.Field(
+        gql_schema.BooksType,
+        genre=graphene.String(),
+        author_id=gql_schema.AuthorId(),
+        lang=graphene.String(),
+        page=graphene.Int(), nb_per_page=graphene.Int()
+    )
+    authors = graphene.Field(
+        gql_schema.AuthorsType,
+        genre=graphene.String(),
+        lang=graphene.String(),
+        page=graphene.Int(), nb_per_page=graphene.Int()
+    )
     featured_books = graphene.List(
         graphene.NonNull(gql_schema.BookType)
     )
@@ -31,32 +50,76 @@ class Query():
         search=graphene.String(required=True),
         lang=graphene.String(),
     )
-    book = graphene.Field(
-        gql_schema.BookType,
-        book_id=gql_schema.BookId(required=True)
-    )
-    book_with_genres_stats = graphene.Field(
-        gql_schema.BookWithGenresStatsType,
-        book_id=gql_schema.BookId(required=True)
-    )
-    author = graphene.Field(
-        gql_schema.AuthorType,
-        author_id=gql_schema.AuthorId(),
-        first_name=graphene.String(),
-        last_name=graphene.String(),
-    )
-    books_by_genre = graphene.Field(
-        gql_schema.BooksByCriteriaType,
-        genre=graphene.String(required=True),
-        lang=graphene.String(),
-        page=graphene.Int(), nb_per_page=graphene.Int()
-    )
-    books_by_author = graphene.Field(
-        gql_schema.BooksByCriteriaType,
-        author_id=gql_schema.AuthorId(required=True),
-        lang=graphene.String(),
-        page=graphene.Int(), nb_per_page=graphene.Int()
-    )
+
+    def resolve_book(self, info: graphql.ResolveInfo, **kwargs) -> t.Union[api_models.Book, None]:
+        public_book_id = kwargs.get('book_id')
+
+        book = library_utils.get_single_book_by_public_id(public_book_id)
+
+        return book
+
+    def resolve_author(self, info: graphql.ResolveInfo, **kwargs) -> t.Union[api_models.Author, None]:
+        public_author_id = kwargs.get('author_id')
+
+        author = library_utils.get_single_author_by_public_id(public_author_id)
+
+        return author
+
+    def resolve_books(self, info: graphql.ResolveInfo, **kwargs) -> gql_schema.BooksType:
+        genre = kwargs.get('genre')
+        public_author_id = kwargs.get('author_id')
+        lang = kwargs.get('lang', LANG_ALL)
+        page = max(int(kwargs.get('page', 1)), 1)
+        nb_per_page = min(int(kwargs.get('nb_per_page', DEFAULT_LIMIT)), MAX_LIMIT)
+
+        books = library_utils.get_books_base_queryset().order_by('title', 'subtitle')
+        if genre:
+            books = books.filter(genres__title=genre)
+        author_id_criteria = None
+        if public_author_id:
+            author_id_criteria = library_utils.get_author_id_criteria(public_author_id)
+            if author_id_criteria.gutenberg_id:
+                books = books.filter(author__gutenberg_id=author_id_criteria.gutenberg_id)
+            else:
+                books = books.filter(author__author_id=author_id_criteria.author_id)
+        if lang != LANG_ALL:
+            books = books.filter(lang=lang)
+
+        offset = (page - 1) * nb_per_page
+        books = books[offset:offset + nb_per_page]
+
+        metadata = _get_books_metadata(author_id_criteria, genre, lang)
+        metadata.page = page
+        metadata.nb_per_page = nb_per_page
+
+        return gql_schema.BooksType(
+            books=list(books),
+            meta=metadata
+        )
+
+    def resolve_authors(self, info: graphql.ResolveInfo, **kwargs) -> gql_schema.AuthorsType:
+        genre = kwargs.get('genre')
+        lang = kwargs.get('lang', LANG_ALL)
+        page = max(int(kwargs.get('page', 1)), 1)
+        nb_per_page = min(int(kwargs.get('nb_per_page', DEFAULT_LIMIT)), MAX_LIMIT)
+
+        authors = library_utils.get_authors_base_queryset().order_by('last_name', 'first_name')
+        if genre:
+            authors = authors.filter(books__genres__title=genre)
+        if lang != LANG_ALL:
+            authors = authors.filter(books__lang=lang)
+
+        offset = (page - 1) * nb_per_page
+        authors = authors[offset:offset + nb_per_page]
+
+        metadata = _get_authors_metadata(genre, lang)
+        metadata.page = page
+        metadata.nb_per_page = nb_per_page
+
+        return gql_schema.AuthorsType(
+            authors=list(authors),
+            meta=metadata
+        )
 
     def resolve_featured_books(self, info: graphql.ResolveInfo, **kwargs) -> t.List[api_models.Book]:
         featured_books_ids = cache.get('featured_books_ids')
@@ -109,152 +172,44 @@ class Query():
         # All right, finally we can return the books results, followed by the authors results:
         return books_quick_completion_results + authors_quick_completion_results
 
-    def resolve_book_with_genres_stats(self, info: graphql.ResolveInfo, **kwargs) -> t.Union[
-        gql_schema.BookWithGenresStatsType, None]:
-        public_book_id = kwargs.get('book_id')
 
-        book = library_utils.get_single_book_by_public_id(public_book_id)
-
-        if book is None:
-            return None
-
-        book_genres_ids = [genre.genre_id for genre in book.genres.all()]
-        book_genres_with_stats = api_models.GenreWithStats.objects.filter(genre_id__in=book_genres_ids)
-
-        returned_genres_with_stats = [
-            _genres_w_stats_to_graphql_equivalent(genre_with_stats)
-            for genre_with_stats in book_genres_with_stats.all()
-        ]
-
-        return gql_schema.BookWithGenresStatsType(
-            book=book,
-            genres_stats=returned_genres_with_stats
-        )
-
-
-
-def _get_books_by_genre_metadata(genre: str, lang: str) -> gql_schema.BooksByCriteriaMetadataType:
+def _get_books_metadata(
+        author_id: t.Optional[library_utils.AuthorIdCriteria] = None,
+        genre: t.Optional[str] = None,
+        lang: t.Optional[str] = None
+) -> gql_schema.ItemsListMetadataType:
+    author_id = author_id or library_utils.AuthorIdCriteria(author_id=0, gutenberg_id=0)
+    genre = genre or ''
+    lang = lang or LANG_ALL
     with connection.cursor() as cursor:
         cursor.execute(
-            """
-            with 
-            input as (
-              select
-                %s::varchar as genre,
-                %s::varchar(3) as lang
-            ),
-            total_count as (
-                select
-                  count(book_id) as count
-                from
-                  library.book as book
-                  join library.book_genre using(book_id)
-                  join library.genre as genre using(genre_id)
-                where
-                  genre.title = (select genre from input) and
-                  case
-                    when (select lang from input) = 'all' then true
-                    else lang = (select lang from input)
-                  end
-            ),
-            total_count_for_all_langs as (
-                select
-                  case
-                    when (select lang from input) = 'all' then
-                      (select count from total_count)::integer
-                    else
-                      (
-                        select
-                          count(*)
-                        from
-                          library.book as book
-                          join library.book_genre using(book_id)
-                          join library.genre as genre using(genre_id)
-                        where
-                          genre.title = (select genre from input)
-                      )::integer
-                  end as count
-            )
-            select
-              (select count from total_count)::integer as total_count,
-              (select count from total_count_for_all_langs)::integer as total_count_for_all_langs
-            """
-            ,
-            [genre, lang]
+            _BOOKS_METADATA_SQL,
+            [genre, author_id.author_id, author_id.gutenberg_id, lang]
         )
         row = cursor.fetchone()
-        metadata = {'total_count': row[0], 'total_count_for_all_langs': row[1]}
+    metadata = {'total_count': row[0], 'total_count_for_all_langs': row[1]}
 
-    return gql_schema.BooksByCriteriaMetadataType(
+    return gql_schema.ItemsListMetadataType(
         total_count=metadata['total_count'],
         total_count_for_all_langs=metadata['total_count_for_all_langs']
     )
 
 
-def _get_books_by_author_metadata(author_id: library_utils.AuthorIdCriteria,
-                                  lang: str) -> gql_schema.BooksByCriteriaMetadataType:
+def _get_authors_metadata(
+        genre: t.Optional[str] = None,
+        lang: t.Optional[str] = None
+) -> gql_schema.ItemsListMetadataType:
+    genre = genre or ''
+    lang = lang or LANG_ALL
     with connection.cursor() as cursor:
         cursor.execute(
-            """
-            with 
-            input as (
-              select
-                %s::integer as author_id,
-                %s::integer as gutenberg_id,
-                %s::varchar(3) as lang
-            ),
-            total_count as (
-                select
-                  count(book_id) as count
-                from
-                  library.book as book
-                  join library.author as author using(author_id)
-                where
-                  case
-                    when (select gutenberg_id from input) = 0 then 
-                      author.author_id = (select author_id from input)
-                    else 
-                      author.gutenberg_id = (select gutenberg_id from input)
-                  end
-                  and
-                  case
-                    when (select lang from input) = 'all' then true
-                    else lang = (select lang from input)
-                  end
-            ),
-            total_count_for_all_langs as (
-                select
-                  case
-                    when (select lang from input) = 'all' then
-                      (select count from total_count)::integer
-                    else
-                      (
-                        select
-                          count(*)
-                        from
-                          library.book as book
-                          join library.author as author using(author_id)
-                        where
-                          case
-                            when (select gutenberg_id from input) = 0 then 
-                              author.author_id = (select author_id from input)
-                            else 
-                              author.gutenberg_id = (select gutenberg_id from input)
-                          end
-                      )::integer
-                  end as count
-            )
-            select
-              (select count from total_count)::integer as total_count,
-              (select count from total_count_for_all_langs)::integer as total_count_for_all_langs
-            """
-            ,
-            [author_id.author_id, author_id.gutenberg_id, lang]
+            _AUTHORS_METADATA_SQL,
+            [genre, lang]
         )
         row = cursor.fetchone()
-        metadata = {'total_count': row[0], 'total_count_for_all_langs': row[1]}
+    metadata = {'total_count': row[0], 'total_count_for_all_langs': row[1]}
 
-    return gql_schema.BooksByCriteriaMetadataType(
+    return gql_schema.ItemsListMetadataType(
         total_count=metadata['total_count'],
         total_count_for_all_langs=metadata['total_count_for_all_langs']
     )
@@ -292,14 +247,144 @@ def _book_to_quick_autocompletion_result(book: api_models.Book) -> gql_schema.Qu
     )
 
 
-def _genres_w_stats_to_graphql_equivalent(genreWithStats: api_models.GenreWithStats) -> gql_schema.GenreStatsType:
-    nb_books_by_lang: t.List[gql_schema.GenreStatsNbBooksByLangType] = [
-        gql_schema.GenreStatsNbBooksByLangType(lang=lang, nb_books=nb_books)
-        for (lang, nb_books) in genreWithStats.nb_books_by_lang.items()
-    ]
-
-    return gql_schema.GenreStatsType(
-        title=genreWithStats.title,
-        nb_books=genreWithStats.nb_books,
-        nb_books_by_lang=nb_books_by_lang
+_BOOKS_METADATA_SQL = \
+    """
+    with 
+    input as (
+      select
+        %s::varchar as genre,
+        %s::integer as author_id,
+        %s::integer as author_pg_id,
+        %s::varchar(3) as lang
+    ),
+    total_count as (
+      select
+        count(distinct book.book_id) as count
+      from
+        library.book as book
+        join library.author as author using(author_id)
+        join library.book_genre using(book_id)
+        join library.genre as genre using(genre_id)
+      where
+        case 
+          when (select genre from input) <> '' then 
+            genre.title = (select genre from input) 
+          else
+            true
+        end
+        and
+        case
+          when (select author_id from input) <> 0 then 
+            author.author_id = (select author_id from input)
+          when (select author_pg_id from input) <> 0 then
+            author.gutenberg_id = (select author_pg_id from input)
+          else
+            true
+        end
+        and
+        case
+          when (select lang from input) <> 'all' then
+            lang = (select lang from input)
+          else 
+            true
+        end
+    ),
+    total_count_for_all_langs as (
+      select
+        case
+          when (select lang from input) = 'all' then
+            (select count from total_count)::integer
+          else
+            (
+              -- same query than "total_count", except that we don't filter by lang this time
+              select
+                count(distinct book.book_id) as count
+              from
+                library.book as book
+                join library.author as author using(author_id)
+                join library.book_genre using(book_id)
+                join library.genre as genre using(genre_id)
+              where
+                case 
+                  when (select genre from input) <> '' then 
+                    genre.title = (select genre from input) 
+                  else
+                    true
+                end
+                and
+                case
+                  when (select author_id from input) <> 0 then 
+                    author.author_id = (select author_id from input)
+                  when (select author_pg_id from input) <> 0 then
+                    author.gutenberg_id = (select author_pg_id from input)
+                  else
+                    true
+                end
+            )::integer
+        end as count
     )
+    select
+      (select count from total_count)::integer as total_count,
+      (select count from total_count_for_all_langs)::integer as total_count_for_all_langs
+    """
+
+_AUTHORS_METADATA_SQL = \
+    """
+    with 
+    input as (
+      select
+        %s::varchar as genre,
+        %s::varchar(3) as lang
+    ),
+    total_count as (
+      select
+        count(distinct author.author_id) as count
+      from
+        library.author as author
+        join library.book as book using(author_id)
+        join library.book_genre using(book_id)
+        join library.genre as genre using(genre_id)
+      where
+        case 
+          when (select genre from input) <> '' then 
+            genre.title = (select genre from input) 
+          else
+            true
+        end
+        and
+        case
+          when (select lang from input) <> 'all' then
+            lang = (select lang from input)
+          else 
+            true
+        end
+    ),
+    total_count_for_all_langs as (
+      select
+        case
+          when (select lang from input) = 'all' then
+            (select count from total_count)::integer
+          else
+            (
+              -- same query than "total_count", except that we don't filter by lang this time
+              select
+                count(distinct author.author_id) as count
+              from
+                library.author as author
+                join library.book as book using(author_id)
+                join library.book_genre using(book_id)
+                join library.genre as genre using(genre_id)
+              where
+                case 
+                  when (select genre from input) <> '' then 
+                    genre.title = (select genre from input) 
+                  else
+                    true
+                end
+            )::integer
+        end as count
+    )
+    select
+      (select count from total_count)::integer as total_count,
+      (select count from total_count_for_all_langs)::integer as total_count_for_all_langs
+    """

--- a/server/api/django/apps/api_public/graphql/library/schema.py
+++ b/server/api/django/apps/api_public/graphql/library/schema.py
@@ -21,11 +21,8 @@ class AuthorId(graphene.String):
 
 
 class QuickAutocompletionResultEnumType(graphene.Enum):
-    # There is a bug in Graphene Python, which uses the Enums names instead of the values.
-    # As long as it's not solved we have to use the Enum names as values, hence the lower-case names.
-    # @link https://github.com/graphql-python/graphql-core/pull/140
-    book = 'book'
-    author = 'author'
+    BOOK = 'book'
+    AUTHOR = 'author'
 
 
 class QuickSearchResultType(graphene.ObjectType):

--- a/server/api/django/apps/api_public/graphql/library/schema.py
+++ b/server/api/django/apps/api_public/graphql/library/schema.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import graphene
 import graphql
 from django.core.exceptions import ObjectDoesNotExist
@@ -12,17 +14,28 @@ import api_public.models as api_models
 BOOK_SIZE_NB_PAGES_RATIO = 800
 
 
-class BookId(graphene.String):
+class BookId(graphene.ID):
     pass
 
 
-class AuthorId(graphene.String):
+class AuthorId(graphene.ID):
     pass
 
 
 class QuickAutocompletionResultEnumType(graphene.Enum):
     BOOK = 'book'
     AUTHOR = 'author'
+
+
+class GenreStatsNbBooksByLangType(graphene.ObjectType):
+    lang = graphene.String()
+    nb_books = graphene.Int()
+
+
+class GenreWithStatsType(graphene.ObjectType):
+    title = graphene.String()
+    nb_books = graphene.Int()
+    nb_books_by_lang = graphene.List(GenreStatsNbBooksByLangType)
 
 
 class QuickSearchResultType(graphene.ObjectType):
@@ -46,6 +59,7 @@ class BookType(DjangoObjectType):
     book_id = BookId()
     genres = graphene.List(graphene.String)
     nb_pages = graphene.Int()
+    genres_with_stats = graphene.List(GenreWithStatsType)
     # A bunch of aliases pointing to the inner 'computed_data' fields :-)
     slug = graphene.String()
     cover_path = graphene.String()
@@ -64,6 +78,16 @@ class BookType(DjangoObjectType):
 
     def resolve_nb_pages(self, info: graphql.ResolveInfo, **kwargs):
         return round(self.size / BOOK_SIZE_NB_PAGES_RATIO)
+
+    def resolve_genres_with_stats(self, info: graphql.ResolveInfo, **kwargs):
+        book_genres_with_stats: t.List['GenreWithStats'] = self.get_genres_with_stats()
+
+        graphql_book_genres_with_stats: t.List[GenreWithStatsType] = [
+            _genres_w_stats_to_graphql_equivalent(genre_with_stats)
+            for genre_with_stats in book_genres_with_stats
+        ]
+
+        return graphql_book_genres_with_stats
 
     def resolve_slug(self, info: graphql.ResolveInfo, **kwargs):
         return self.computed_data.slug
@@ -122,29 +146,31 @@ class AuthorType(DjangoObjectType):
         exclude_fields = ('gutenberg_id', 'computed_data', 'highlight')
 
 
-class BooksByCriteriaMetadataType(graphene.ObjectType):
+class ItemsListMetadataType(graphene.ObjectType):
     total_count = graphene.Int(required=True)
     total_count_for_all_langs = graphene.Int(required=True)
     page = graphene.Int(required=True)
     nb_per_page = graphene.Int(required=True)
 
 
-class BooksByCriteriaType(graphene.ObjectType):
+class BooksType(graphene.ObjectType):
     books = graphene.List(graphene.NonNull(BookType))
-    meta = graphene.Field(graphene.NonNull(BooksByCriteriaMetadataType))
+    meta = graphene.Field(graphene.NonNull(ItemsListMetadataType))
 
 
-class GenreStatsNbBooksByLangType(graphene.ObjectType):
-    lang = graphene.String()
-    nb_books = graphene.Int()
+class AuthorsType(graphene.ObjectType):
+    authors = graphene.List(graphene.NonNull(AuthorType))
+    meta = graphene.Field(graphene.NonNull(ItemsListMetadataType))
 
 
-class GenreStatsType(graphene.ObjectType):
-    title = graphene.String()
-    nb_books = graphene.Int()
-    nb_books_by_lang = graphene.List(GenreStatsNbBooksByLangType)
+def _genres_w_stats_to_graphql_equivalent(genreWithStats: api_models.GenreWithStats) -> GenreWithStatsType:
+    nb_books_by_lang: t.List[GenreStatsNbBooksByLangType] = [
+        GenreStatsNbBooksByLangType(lang=lang, nb_books=nb_books)
+        for (lang, nb_books) in genreWithStats.nb_books_by_lang.items()
+    ]
 
-
-class BookWithGenresStatsType(graphene.ObjectType):
-    book = graphene.Field(BookType)
-    genres_stats = graphene.List(GenreStatsType)
+    return GenreWithStatsType(
+        title=genreWithStats.title,
+        nb_books=genreWithStats.nb_books,
+        nb_books_by_lang=nb_books_by_lang
+    )

--- a/server/api/django/apps/api_public/graphql/library/schema.py
+++ b/server/api/django/apps/api_public/graphql/library/schema.py
@@ -1,3 +1,4 @@
+import enum
 import typing as t
 
 import graphene
@@ -22,28 +23,24 @@ class AuthorId(graphene.ID):
     pass
 
 
-class QuickAutocompletionResultEnumType(graphene.Enum):
+class QuickAutocompletionResultType(enum.Enum):
     BOOK = 'book'
     AUTHOR = 'author'
 
 
-class GenreStatsNbBooksByLangType(graphene.ObjectType):
+class GenreStatsNbBooksByLang(graphene.ObjectType):
     lang = graphene.String()
     nb_books = graphene.Int()
 
 
-class GenreWithStatsType(graphene.ObjectType):
+class GenreWithStats(graphene.ObjectType):
     title = graphene.String()
     nb_books = graphene.Int()
-    nb_books_by_lang = graphene.List(GenreStatsNbBooksByLangType)
+    nb_books_by_lang = graphene.List(GenreStatsNbBooksByLang)
 
 
-class QuickSearchResultType(graphene.ObjectType):
-    type = QuickAutocompletionResultEnumType()
-    book_id = BookId()
-    book_title = graphene.String()
-    book_lang = graphene.String()
-    book_slug = graphene.String()
+class QuickSearchResultInterface(graphene.Interface):
+    type = graphene.Field(graphene.Enum.from_enum(QuickAutocompletionResultType))
     author_id = AuthorId(required=True)
     author_first_name = graphene.String()
     author_last_name = graphene.String()
@@ -51,15 +48,33 @@ class QuickSearchResultType(graphene.ObjectType):
     author_nb_books = graphene.Int(required=True)
     highlight = graphene.Int(required=True)
 
+
+class QuickSearchResultAuthor(graphene.ObjectType):
+    class Meta:
+        interfaces = (QuickSearchResultInterface,)
+
     def resolve_type(self, info: graphql.ResolveInfo, **kwargs):
-        return self.type.value
+        return QuickAutocompletionResultType.AUTHOR.value
 
 
-class BookType(DjangoObjectType):
+class QuickSearchResultBook(graphene.ObjectType):
+    class Meta:
+        interfaces = (QuickSearchResultInterface,)
+
+    book_id = BookId(required=True)
+    book_title = graphene.String(required=True)
+    book_lang = graphene.String(required=True)
+    book_slug = graphene.String(required=True)
+
+    def resolve_type(self, info: graphql.ResolveInfo, **kwargs):
+        return QuickAutocompletionResultType.BOOK.value
+
+
+class Book(DjangoObjectType):
     book_id = BookId()
     genres = graphene.List(graphene.String)
     nb_pages = graphene.Int()
-    genres_with_stats = graphene.List(GenreWithStatsType)
+    genres_with_stats = graphene.List(GenreWithStats)
     # A bunch of aliases pointing to the inner 'computed_data' fields :-)
     slug = graphene.String()
     cover_path = graphene.String()
@@ -82,7 +97,7 @@ class BookType(DjangoObjectType):
     def resolve_genres_with_stats(self, info: graphql.ResolveInfo, **kwargs):
         book_genres_with_stats: t.List['GenreWithStats'] = self.get_genres_with_stats()
 
-        graphql_book_genres_with_stats: t.List[GenreWithStatsType] = [
+        graphql_book_genres_with_stats: t.List[GenreWithStats] = [
             _genres_w_stats_to_graphql_equivalent(genre_with_stats)
             for genre_with_stats in book_genres_with_stats
         ]
@@ -118,7 +133,7 @@ class BookType(DjangoObjectType):
         exclude_fields = ('gutenberg_id', 'computed_data', 'highlight', 'size')
 
 
-class AuthorType(DjangoObjectType):
+class Author(DjangoObjectType):
     author_id = AuthorId()
     # A bunch of aliases pointing to the inner 'computed_data' fields :-)
     full_name = graphene.String()
@@ -146,30 +161,30 @@ class AuthorType(DjangoObjectType):
         exclude_fields = ('gutenberg_id', 'computed_data', 'highlight')
 
 
-class ItemsListMetadataType(graphene.ObjectType):
+class ItemsListMetadata(graphene.ObjectType):
     total_count = graphene.Int(required=True)
     total_count_for_all_langs = graphene.Int(required=True)
     page = graphene.Int(required=True)
     nb_per_page = graphene.Int(required=True)
 
 
-class BooksType(graphene.ObjectType):
-    books = graphene.List(graphene.NonNull(BookType))
-    meta = graphene.Field(graphene.NonNull(ItemsListMetadataType))
+class BooksList(graphene.ObjectType):
+    books = graphene.List(graphene.NonNull(Book))
+    meta = graphene.Field(graphene.NonNull(ItemsListMetadata))
 
 
-class AuthorsType(graphene.ObjectType):
-    authors = graphene.List(graphene.NonNull(AuthorType))
-    meta = graphene.Field(graphene.NonNull(ItemsListMetadataType))
+class AuthorsList(graphene.ObjectType):
+    authors = graphene.List(graphene.NonNull(Author))
+    meta = graphene.Field(graphene.NonNull(ItemsListMetadata))
 
 
-def _genres_w_stats_to_graphql_equivalent(genreWithStats: api_models.GenreWithStats) -> GenreWithStatsType:
-    nb_books_by_lang: t.List[GenreStatsNbBooksByLangType] = [
-        GenreStatsNbBooksByLangType(lang=lang, nb_books=nb_books)
+def _genres_w_stats_to_graphql_equivalent(genreWithStats: api_models.GenreWithStats) -> GenreWithStats:
+    nb_books_by_lang: t.List[GenreStatsNbBooksByLang] = [
+        GenreStatsNbBooksByLang(lang=lang, nb_books=nb_books)
         for (lang, nb_books) in genreWithStats.nb_books_by_lang.items()
     ]
 
-    return GenreWithStatsType(
+    return GenreWithStats(
         title=genreWithStats.title,
         nb_books=genreWithStats.nb_books,
         nb_books_by_lang=nb_books_by_lang

--- a/server/api/django/apps/api_public/graphql/library/utils.py
+++ b/server/api/django/apps/api_public/graphql/library/utils.py
@@ -70,3 +70,16 @@ def get_single_book_by_public_id(public_book_id: str) -> api_models.Book:
         criteria['author_id'] = book_id_criteria.author_id
 
     return books.get(**criteria)
+
+
+def get_single_author_by_public_id(public_author_id: str) -> api_models.Author:
+    author_id_criteria = get_author_id_criteria(public_author_id)
+
+    authors = get_authors_base_queryset()
+    criteria = dict()
+    if author_id_criteria.gutenberg_id:
+        criteria['gutenberg_id'] = author_id_criteria.gutenberg_id
+    else:
+        criteria['author_id'] = author_id_criteria.author_id
+
+    return authors.get(**criteria)

--- a/server/api/django/apps/api_public/graphql_schema.py
+++ b/server/api/django/apps/api_public/graphql_schema.py
@@ -2,6 +2,7 @@ import graphene
 from django.conf import settings
 from graphene_django.debug import DjangoDebug
 
+import api_public.graphql.library.schema as gql_schema
 from api_public.graphql.library.query import Query as LibraryQuery
 
 
@@ -11,4 +12,5 @@ class Query(LibraryQuery, graphene.ObjectType):
     debug = graphene.Field(DjangoDebug, name='__debug') if settings.DEBUG else None
 
 
-schema = graphene.Schema(query=Query)
+schema = graphene.Schema(query=Query,
+                         types=[gql_schema.QuickSearchResultBook, gql_schema.QuickSearchResultAuthor], )


### PR DESCRIPTION
Improve tons of things here and there, because our GraphQL API was first modeled after the PostgREST one (with different Postgres functions for each type of query); but in fact we can improve a lot of things if we use GraphQL possibilities properly.

So now we have the following:
 * a `QuickSearchResultInterface`, with 2 implementations (`QuickSearchResultAuthor` & `QuickSearchResultBook`)
* a unified "books" query, that allow the client to query books without any criteria or with one or a combination of those ones: `genre`, `authorId`, `lang`
* a unified "authors" query, that allow the client to query authors without any criteria or with one or a combination of those ones: `genre`, `lang`
* the "genreWithStats" is now a simple field of our `Book` type, instead of being part of a dedicated query